### PR TITLE
lockdep: trying to register non-static key

### DIFF
--- a/src/igb_main.c
+++ b/src/igb_main.c
@@ -3516,6 +3516,7 @@ static int igb_sw_init(struct igb_adapter *adapter)
 
 	adapter->max_frame_size = netdev->mtu + ETH_HLEN + ETH_FCS_LEN +
 					      VLAN_HLEN;
+	spin_lock_init(&adapter->nfc_lock);
 
 	/* Initialize the hardware-specific values */
 	if (e1000_setup_init_funcs(hw, TRUE)) {


### PR DESCRIPTION
Fix https://github.com/intel/ethernet-linux-igb/issues/4

If kernel configured with CONFIG_LOCKDEP, then we got with warning:

```
INFO: trying to register non-static key.
The code is fine but needs lockdep annotation, or maybe
you didn't initialize this object before use?
turning off the locking correctness validator.
```

